### PR TITLE
Implement TLS connections, default to TLS connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - add long options for commands to improve readability
 - add descriptions to commands
+- parameter for port
+- parameter to disable use of TLS encryption
+
+### Changed
+- change default call to check via TLS on port 993
 
 ## [0.0.2] - 2015-07-14
 ### Changed

--- a/test/check_imap_spec.rb
+++ b/test/check_imap_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../bin/check-imap.rb'
+
+# Class Stub for the check
+class CheckIMAP
+  at_exit do
+    @autorun = false
+  end
+
+  def critical(*); end
+
+  def warning(*); end
+
+  def ok(*); end
+end
+
+describe 'CheckIMAP' do
+  describe '#run' do
+    it 'opens a TLS connection by default' do
+      check = CheckIMAP.new
+      expect(Net::IMAP).to receive(:new).with(check.config[:host].to_s,
+                                              993,
+                                              true)
+      check.run
+    end
+
+    it 'opens a plain text connection when TLS is disabled' do
+      check = CheckIMAP.new('--disable-tls'.split(' '))
+      expect(Net::IMAP).to receive(:new).with(check.config[:host].to_s)
+      check.run
+    end
+
+    it 'opens a plain text connection with a specified host on request' do
+      check = CheckIMAP.new('--disable-tls --port 143'.split(' '))
+      expect(check.config[:disable_tls]).to be true
+      expect(check.config[:port].to_i).to eq(143)
+      expect(Net::IMAP).to receive(:new).with(check.config[:host].to_s, 143)
+      check.run
+    end
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [ ] Existing tests pass 
#### New Plugins
- [ ] Tests
- [ ] Add the plugin to the README
- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose

Changes default plain text connection to TLS.
#### Known Compatablity Issues

(btw, there's a typo in the your header ;) )

It's 2016, we have Let's Encrypt. (and we're not deprecating plain text
connections. In fact we make an educated guess which ports are going to
be used.)
